### PR TITLE
Updated ollama pull command

### DIFF
--- a/chat_with_deepseek_r1_locally/README.md
+++ b/chat_with_deepseek_r1_locally/README.md
@@ -29,7 +29,7 @@ pip install -r requirements.txt
 ### 3. Pull and Run DeepSeek-r1 Using Ollama  
 Download and set up the DeepSeek-r1 model locally:  
 ```bash  
-ollama pull deepseek-r1:1.5
+ollama pull deepseek-r1:1.5b
 ```  
 
 ### 4. Run the Reflex App  


### PR DESCRIPTION
`ollama pull deepseek-r1:1.5`  returns the following error:

>Error: pull model manifest: file does not exist

Changing the command to `ollama pull deepseek-r1:1.5b` successfully loads the model.

